### PR TITLE
ci(*): run integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,6 +105,30 @@ jobs:
             *.tar.gz
             *.json
 
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install rust target for example app
+        run: rustup target add wasm32-wasip2
+
+      - name: Install Spin
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          # TODO: Switch to Spin 4.0 when it's available
+          version: "canary"
+          plugins: pluginify
+
+      - name: Install mqttx-cli
+        run: |
+          curl -LO https://www.emqx.com/en/downloads/MQTTX/v1.13.0/mqttx-cli-linux-x64
+          sudo install ./mqttx-cli-linux-x64 /usr/local/bin/mqttx
+
+      - name: Run integration test
+        run: make test
+
   package:
     name: Package plugin
     if: github.event_name == 'push'

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -132,7 +132,8 @@ start_spin_app() {
     SPIN_LOGS_STDOUT="$SPIN_LOG_DIR/mqtt-c01_stdout.txt"
     
     # Build and start the example app in background, capturing output
-    spin build --up --from examples/mqtt-app/spin.toml --log-dir "$SPIN_LOG_DIR" &
+    spin build --from examples/mqtt-app/spin.toml
+    spin up --from examples/mqtt-app/spin.toml --log-dir "$SPIN_LOG_DIR" &
     SPIN_PID=$!
     
     log "Waiting for Spin application to start..."


### PR DESCRIPTION
- Adds the integration tests to CI
- Tweaks the test itself to first build the app completely (this can take some time) and then only background the running process -- otherwise the test was liable to move forward while the app was still building and fail the subsequent checks.

The build workflow could use some TLC and refactoring, but I'm thinking it would be best to defer on account of https://github.com/spinframework/spin/issues/3457.